### PR TITLE
Add fountain encoding using pywirehair

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,14 @@ python -m cimbar.cimbar --encode myinputfile.txt encoded.png
 
 ```
 python -m cimbar.cimbar encoded.png myoutputfile.txt
+python -m cimbar.cimbar /tmp/encoded.png -o /tmp/myoutputfile.txt
 ```
 
 There are also some utility scripts, such as the one to measure bit errors:
 
 ```
-python -m cimbar.cimbar --deskew=0 --ecc=0 encoded.png clean.txt
-python -m cimbar.cimbar --ecc=0 camera/001.jpg decode.txt
+python -m cimbar.cimbar encoded.png -o clean.txt --deskew=0 --ecc=0
+python -m cimbar.cimbar camera/001.jpg -o decode.txt --ecc=0
 python -m cimbar.grader clean.txt decode.txt
 ```
 

--- a/cimbar/cimbar.py
+++ b/cimbar/cimbar.py
@@ -11,7 +11,7 @@ Usage:
 
 Examples:
   python -m cimbar --encode myfile.txt cimb-code.png
-  python -m cimbar cimb-code.png myfile.txt
+  python -m cimbar cimb-code.png -o myfile.txt
 
 Options:
   -h --help                        Show this help.

--- a/cimbar/fountain/fountain_decoder_stream.py
+++ b/cimbar/fountain/fountain_decoder_stream.py
@@ -1,0 +1,43 @@
+from .header import fountain_header
+
+class fountain_decoder_stream:
+    def __init__(self, f, total_size, chunk_size):
+        self.write_size = chunk_size
+        self.chunk_size = chunk_size - fountain_header.length
+        if isinstance(f, str):
+            self.f = open(f, 'wb')
+        else:
+            self.f = f
+        self._reset(total_size)
+
+    @property
+    def closed(self):
+        return self.f.closed
+
+    def __enter__(self):
+        self._load()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if not self.f.closed:
+            with self.f:  # close file
+                pass
+
+    def _reset(self, total_size):
+        from pywirehair import decoder
+        self.fountain = decoder(total_size, self.chunk_size)
+
+    def write(self, buffer):
+        if len(buffer) % self.write_size != 0:
+            raise Exception(f'{len(buffer)} must be a multiple of {self.write_size}')
+
+        # split buffer into header,chunk
+        # get chunk_id from header
+        hdr = fountain_header(buffer[0:fountain_header.length])
+
+        res = self.fountain.decode(hdr.chunk_id, buffer[fountain_header.length:])
+        if not res:
+            return False
+
+        self.f.write(res)
+        return True

--- a/cimbar/fountain/fountain_decoder_stream.py
+++ b/cimbar/fountain/fountain_decoder_stream.py
@@ -15,7 +15,6 @@ class fountain_decoder_stream:
         return self.f.closed
 
     def __enter__(self):
-        self._load()
         return self
 
     def __exit__(self, type, value, traceback):

--- a/cimbar/fountain/fountain_decoder_stream.py
+++ b/cimbar/fountain/fountain_decoder_stream.py
@@ -1,14 +1,14 @@
 from .header import fountain_header
 
 class fountain_decoder_stream:
-    def __init__(self, f, total_size, chunk_size):
+    def __init__(self, f, chunk_size):
         self.write_size = chunk_size
         self.chunk_size = chunk_size - fountain_header.length
         if isinstance(f, str):
             self.f = open(f, 'wb')
         else:
             self.f = f
-        self._reset(total_size)
+        self.fountain = None
 
     @property
     def closed(self):
@@ -32,8 +32,11 @@ class fountain_decoder_stream:
             raise Exception(f'{len(buffer)} must be a multiple of {self.write_size}')
 
         # split buffer into header,chunk
-        # get chunk_id from header
+        # get chunk_id and total_size from header
         hdr = fountain_header(buffer[0:fountain_header.length])
+
+        if not self.fountain:
+            self._reset(hdr.total_size)
 
         res = self.fountain.decode(hdr.chunk_id, buffer[fountain_header.length:])
         if not res:

--- a/cimbar/fountain/fountain_encoder_stream.py
+++ b/cimbar/fountain/fountain_encoder_stream.py
@@ -1,4 +1,3 @@
-
 from .header import fountain_header
 
 

--- a/cimbar/fountain/fountain_encoder_stream.py
+++ b/cimbar/fountain/fountain_encoder_stream.py
@@ -4,6 +4,7 @@ from .header import fountain_header
 class fountain_encoder_stream:
     def __init__(self, f, chunk_size, encode_id=0):
         self.buffer = b''
+        self.read_size = chunk_size
         self.chunk_size = chunk_size - fountain_header.length
         self.encode_id = encode_id
 
@@ -18,7 +19,6 @@ class fountain_encoder_stream:
         return self.f.closed
 
     def __enter__(self):
-        self._load()
         return self
 
     def __exit__(self, type, value, traceback):
@@ -36,7 +36,10 @@ class fountain_encoder_stream:
     def _header(self, chunk_id):
         return bytes(fountain_header(self.encode_id, self.len, chunk_id))
 
-    def read(self):
+    def read(self, max_bytes):
+        if max_bytes % self.read_size != 0:
+            raise Exception(f'{max_bytes} must be a multiple of {self.read_size}')
+
         bites = b''
         while len(bites) < self.chunk_size:
             bites = self.fountain.encode(self.chunk_id)

--- a/cimbar/fountain/fountain_encoder_stream.py
+++ b/cimbar/fountain/fountain_encoder_stream.py
@@ -1,0 +1,72 @@
+
+
+def int_to_bytes(n):
+    return n.to_bytes((n.bit_length() + 7) // 8, 'big')
+
+
+def int_from_bytes(bites):
+    return int.from_bytes(bites, 'big')
+
+
+class fountain_header:
+    pass
+
+
+class fountain_stream:
+    def __init__(self, f, chunk_size, f_size=None, mode='read'):
+        if mode not in ['read', 'write']:
+            raise Exception('bad bit_file mode. Try "read" or "write"')
+        self.mode = mode
+
+        self.buffer = b''
+        self.chunk_size = chunk_size
+
+        if isinstance(f, str):
+            fmode = 'wb' if mode == 'write' else 'rb'
+            self.f = open(f, fmode)
+        else:
+            self.f = f
+        self._load(f_size)
+
+    @property
+    def closed(self):
+        return self.f.closed
+
+    def __enter__(self):
+        self._load()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if not self.f.closed:
+            with self.f:  # close file
+                pass
+
+    # split this into fountain_encoder_stream and fountain_decoder_stream?
+    # the if blocks aren't helping us enough?
+    def _load(self, f_size=None):
+        from pywirehair import encoder, decoder
+        if self.mode == 'write':
+            contents = self.f.read()
+            self.fountain = encoder(contents, self.chunk_size)
+            self.chunk_id = 0
+            self.len = len(contents)
+        else:
+            self.fountain = decoder(f_size)
+
+    def _header(self, chunk_id):
+        return b''
+
+    def write(self, buffer):
+        if len(buffer) % self.chunk_size != 0:
+            raise Exception(f'{len(buffer)} must be a multiple of {self.chunk_size}')
+
+        # split buffer into header,chunk
+        # get chunk_id from header
+        self.fountain.decode(chunk_id, buffer)
+
+    def read(self):
+        bites = b''
+        while len(bites) < self.chunk_size:
+            bites = self.fountain.encode(self.chunk_id)
+            self.chunk_id += 1
+        return bites

--- a/cimbar/fountain/header.py
+++ b/cimbar/fountain/header.py
@@ -1,0 +1,27 @@
+
+def int_to_bytes(n, num_bytes):
+    return n.to_bytes(num_bytes, 'big')
+
+
+def int_from_bytes(bites):
+    return int.from_bytes(bites, 'big')
+
+
+class fountain_header:
+    def __init__(self, encode_id, total_size=None, chunk_id=None):
+        if total_size is None:
+            self.encode_id, self.total_size, self.chunk_id = self.from_encoded(encode_id)
+        else:
+            self.encode_id = encode_id
+            self.total_size = total_size
+            self.chunk_id = chunk_id
+
+    def __bytes__(self):
+        return int_to_bytes(self.encode_id, 1) + int_to_bytes(self.total_size, 3) + int_to_bytes(self.chunk_id, 2)
+
+    @classmethod
+    def from_encoded(cls, encoded_bytes):
+        encode_id = int_from_bytes(encoded_bytes[0:1])
+        total_size = int_from_bytes(encoded_bytes[1:4])
+        chunk_id = int_from_bytes(encoded_bytes[4:6])
+        return encode_id, total_size, chunk_id

--- a/cimbar/fountain/header.py
+++ b/cimbar/fountain/header.py
@@ -8,6 +8,8 @@ def int_from_bytes(bites):
 
 
 class fountain_header:
+    length = 6
+
     def __init__(self, encode_id, total_size=None, chunk_id=None):
         if total_size is None:
             self.encode_id, self.total_size, self.chunk_id = self.from_encoded(encode_id)

--- a/cimbar/fountain/header.py
+++ b/cimbar/fountain/header.py
@@ -17,11 +17,16 @@ class fountain_header:
             self.chunk_id = chunk_id
 
     def __bytes__(self):
-        return int_to_bytes(self.encode_id, 1) + int_to_bytes(self.total_size, 3) + int_to_bytes(self.chunk_id, 2)
+        eid = self.encode_id + ((self.total_size & 0x1000000) >> 17)
+        sz = self.total_size & 0xFFFFFF
+        return int_to_bytes(eid, 1) + int_to_bytes(sz, 3) + int_to_bytes(self.chunk_id, 2)
 
     @classmethod
     def from_encoded(cls, encoded_bytes):
         encode_id = int_from_bytes(encoded_bytes[0:1])
         total_size = int_from_bytes(encoded_bytes[1:4])
         chunk_id = int_from_bytes(encoded_bytes[4:6])
+
+        total_size = total_size | ((encode_id & 0x80) << 17)
+        encode_id = encode_id & 0x7F
         return encode_id, total_size, chunk_id

--- a/cimbar/util/bit_file.py
+++ b/cimbar/util/bit_file.py
@@ -6,7 +6,7 @@ MAX_ENCODING = 16384
 
 
 class bit_file:
-    def __init__(self, f, bits_per_op, mode='read', read_size=MAX_ENCODING, read_count=1):
+    def __init__(self, f, bits_per_op, mode='read', keep_open=False, read_size=MAX_ENCODING, read_count=1):
         if mode not in ['read', 'write']:
             raise Exception('bad bit_file mode. Try "read" or "write"')
         self.mode = mode
@@ -14,8 +14,10 @@ class bit_file:
         if isinstance(f, str):
             fmode = 'wb' if mode == 'write' else 'rb'
             self.f = open(f, fmode)
+            self.keep_open = False
         else:
             self.f = f
+            self.keep_open = keep_open  # determines whether __exit__ is a flush()+close(), or just a flush()
         self.bits_per_op = bits_per_op
         self.stream = BitStream()
 
@@ -28,7 +30,7 @@ class bit_file:
     def __exit__(self, type, value, traceback):
         if self.mode == 'write' and not self.f.closed:
             self.save()
-        if not self.f.closed:
+        if not self.keep_open and not self.f.closed:
             with self.f:  # close file
                 pass
 

--- a/requirements
+++ b/requirements
@@ -5,4 +5,5 @@ numpy
 opencv-python
 pillow
 reedsolo
+zstandard
 https://github.com/sz3/pywirehair/archive/master.zip

--- a/requirements
+++ b/requirements
@@ -5,3 +5,4 @@ numpy
 opencv-python
 pillow
 reedsolo
+https://github.com/sz3/pywirehair/archive/master.zip

--- a/tests/test_cimbar.py
+++ b/tests/test_cimbar.py
@@ -85,15 +85,15 @@ class CimbarTest(TestCase):
         self.assertTrue(path.getsize(self.encoded_file) > 0)
 
         out_path = self._temp_path('outfile.txt')
-        decode(self.encoded_file, out_path, dark=True, deskew=False)
+        decode([self.encoded_file], out_path, dark=True, deskew=False)
         self.validate_output(out_path)
 
         out_no_ecc = self._temp_path('outfile_no_ecc.txt')
-        decode(self.encoded_file, out_no_ecc, dark=True, ecc=0, deskew=False)
+        decode([self.encoded_file], out_no_ecc, dark=True, ecc=0, deskew=False)
         self.validate_grader(out_no_ecc, 1)
 
         out_no_ecc = self._temp_path('outfile_no_ecc.txt')
-        decode(self.encoded_file, out_no_ecc, dark=True, ecc=0)
+        decode([self.encoded_file], out_no_ecc, dark=True, ecc=0)
         self.validate_grader(out_no_ecc, 200)
 
     def test_decode_perspective(self):
@@ -101,15 +101,15 @@ class CimbarTest(TestCase):
         _warp1(self.encoded_file, skewed_image)
 
         out_no_ecc = self._temp_path('outfile_no_ecc.txt')
-        decode(skewed_image, out_no_ecc, dark=True, ecc=0)
+        decode([skewed_image], out_no_ecc, dark=True, ecc=0)
         self.validate_grader(out_no_ecc, 2000)
 
     def test_decode_perspective_rotate(self):
         skewed_image = self._temp_path('skewed2.jpg')
         _warp2(self.encoded_file, skewed_image)
 
-        out_no_ecc = self._temp_path('outfile_no_ecc.txt')
-        decode(skewed_image, out_no_ecc, dark=True, ecc=0)
+        out_no_ecc = self._temp_path('outfile_no_ecc2.txt')
+        decode([skewed_image], out_no_ecc, dark=True, ecc=0)
         self.validate_grader(out_no_ecc, 4000)
 
     def test_decode_sample(self):
@@ -117,10 +117,10 @@ class CimbarTest(TestCase):
         warped_image = 'samples/6bit/4_30_802.jpg'
 
         clean_bits = self._temp_path('outfile_clean.txt')
-        decode(clean_image, clean_bits, dark=True, ecc=0, auto_dewarp=False)
+        decode([clean_image], clean_bits, dark=True, ecc=0, auto_dewarp=False)
 
         warped_bits = self._temp_path('outfile_warped.txt')
-        decode(warped_image, warped_bits, dark=True, ecc=0, auto_dewarp=False)
+        decode([warped_image], warped_bits, dark=True, ecc=0, auto_dewarp=False)
 
         num_bits = evaluate_grader(clean_bits, warped_bits, BITS_PER_OP, True)
         self.assertLess(num_bits, 350)

--- a/tests/test_fountain.py
+++ b/tests/test_fountain.py
@@ -1,0 +1,33 @@
+from io import BytesIO
+from os import path
+from unittest import TestCase
+
+from cimbar.fountain.header import fountain_header
+from cimbar.fountain.fountain_encoder_stream import fountain_encoder_stream
+
+
+CIMBAR_ROOT = path.abspath(path.join(path.dirname(path.realpath(__file__)), '..'))
+
+
+
+class FountainHeaderTest(TestCase):
+    def test_header_encode(self):
+        self.assertEqual(b'\x01\x00\x04\x00\x00\x03', bytes(fountain_header(1, 1024, 3)))
+
+    def test_header_decode(self):
+        f = fountain_header(b'\x01\x00\x04\x00\x00\x03')
+        self.assertEqual(1, f.encode_id)
+        self.assertEqual(1024, f.total_size)
+        self.assertEqual(3, f.chunk_id)
+
+    def test_header_decode_2(self):
+        f = fountain_header(b'\x0a\x07\x08\x09\x00\x00')
+        self.assertEqual(10, f.encode_id)
+        self.assertEqual(0x070809, f.total_size)
+        self.assertEqual(0, f.chunk_id)
+
+
+class FountainTest(TestCase):
+    def test_encode_decode(self):
+        self.assertFalse(True)
+

--- a/tests/test_fountain.py
+++ b/tests/test_fountain.py
@@ -58,7 +58,7 @@ class FountainTest(TestCase):
         fes = fountain_encoder_stream(inbuff, 400)
 
         outbuff = BytesIO()
-        dec = fountain_decoder_stream(outbuff, len(data), 400)
+        dec = fountain_decoder_stream(outbuff, 400)
 
         r = fes.read()
         self.assertFalse(dec.write(r))

--- a/tests/test_fountain.py
+++ b/tests/test_fountain.py
@@ -20,11 +20,26 @@ class FountainHeaderTest(TestCase):
         self.assertEqual(1024, f.total_size)
         self.assertEqual(3, f.chunk_id)
 
-    def test_header_decode_2(self):
+    def test_header_decode_consistency(self):
         f = fountain_header(b'\x0a\x07\x08\x09\x00\x00')
         self.assertEqual(10, f.encode_id)
         self.assertEqual(0x070809, f.total_size)
         self.assertEqual(0, f.chunk_id)
+
+    def test_header_encode_bigfile(self):
+        fe = fountain_header(2, 0x1FFFFFF, 3)
+        self.assertEqual(b'\x82\xff\xff\xff\x00\x03', bytes(fe))
+
+    def test_header_decode_bigfile(self):
+
+        f = fountain_header(b'\x81\x07\x08\x09\x00\x00')
+        self.assertEqual(1, f.encode_id)
+        self.assertEqual(0x1070809, f.total_size)
+        self.assertEqual(0, f.chunk_id)
+
+        # round trip
+        fe = fountain_header(1, 0x1070809, 0)
+        self.assertEqual(b'\x81\x07\x08\x09\x00\x00', bytes(fe))
 
 
 class FountainTest(TestCase):

--- a/tests/test_fountain.py
+++ b/tests/test_fountain.py
@@ -3,6 +3,7 @@ from os import path
 from unittest import TestCase
 
 from cimbar.fountain.header import fountain_header
+from cimbar.fountain.fountain_decoder_stream import fountain_decoder_stream
 from cimbar.fountain.fountain_encoder_stream import fountain_encoder_stream
 
 
@@ -50,3 +51,23 @@ class FountainTest(TestCase):
         r = fes.read()
 
         self.assertEqual(b'\x00\x00\x03\xe8\x00\x00' + data[:394], r)
+
+    def test_round_trip(self):
+        data = b'0123456789' * 100
+        inbuff = BytesIO(data)
+        fes = fountain_encoder_stream(inbuff, 400)
+
+        outbuff = BytesIO()
+        dec = fountain_decoder_stream(outbuff, len(data), 400)
+
+        r = fes.read()
+        self.assertFalse(dec.write(r))
+
+        r = fes.read()
+        self.assertFalse(dec.write(r))
+
+        r = fes.read()
+        self.assertTrue(dec.write(r))
+
+        outbuff.seek(0)
+        self.assertEqual(data, outbuff.read())

--- a/tests/test_fountain.py
+++ b/tests/test_fountain.py
@@ -48,7 +48,7 @@ class FountainTest(TestCase):
         inbuff = BytesIO(data)
 
         fes = fountain_encoder_stream(inbuff, 400)
-        r = fes.read()
+        r = fes.read(400)
 
         self.assertEqual(b'\x00\x00\x03\xe8\x00\x00' + data[:394], r)
 
@@ -60,13 +60,13 @@ class FountainTest(TestCase):
         outbuff = BytesIO()
         dec = fountain_decoder_stream(outbuff, 400)
 
-        r = fes.read()
+        r = fes.read(400)
         self.assertFalse(dec.write(r))
 
-        r = fes.read()
+        r = fes.read(400)
         self.assertFalse(dec.write(r))
 
-        r = fes.read()
+        r = fes.read(400)
         self.assertTrue(dec.write(r))
 
         outbuff.seek(0)

--- a/tests/test_fountain.py
+++ b/tests/test_fountain.py
@@ -7,7 +7,7 @@ from cimbar.fountain.fountain_encoder_stream import fountain_encoder_stream
 
 
 CIMBAR_ROOT = path.abspath(path.join(path.dirname(path.realpath(__file__)), '..'))
-
+SAMPLE_FILE = path.join(CIMBAR_ROOT, 'LICENSE')
 
 
 class FountainHeaderTest(TestCase):
@@ -31,7 +31,6 @@ class FountainHeaderTest(TestCase):
         self.assertEqual(b'\x82\xff\xff\xff\x00\x03', bytes(fe))
 
     def test_header_decode_bigfile(self):
-
         f = fountain_header(b'\x81\x07\x08\x09\x00\x00')
         self.assertEqual(1, f.encode_id)
         self.assertEqual(0x1070809, f.total_size)
@@ -43,6 +42,11 @@ class FountainHeaderTest(TestCase):
 
 
 class FountainTest(TestCase):
-    def test_encode_decode(self):
-        self.assertFalse(True)
+    def test_encode(self):
+        data = b'0123456789' * 100
+        inbuff = BytesIO(data)
 
+        fes = fountain_encoder_stream(inbuff, 400)
+        r = fes.read()
+
+        self.assertEqual(b'\x00\x00\x03\xe8\x00\x00' + data[:394], r)


### PR DESCRIPTION
Parity with [libcimbar](https://github.com/sz3/libcimbar). zstd applied to the entire file contents when loaded, and wirehair operates on this compressed data stream.

The "wire" format itself is a 6 byte header per fountain chunk, with 10 fountain chunks neatly dividing the payload of one cimbar frame.